### PR TITLE
update for v2.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This ArchivesSpace plugin adds functionality for various aspects of the Bentley 
 ## How it Works
 The backend modifications include several API endpoints, defined in `backend/controllers/bhl_barcode.rb`, which return information based on certain parameters. Each API endpoint calls a function of the `BHLBarcode` class, defined in `backend/model/bhl_barcode.rb`, which interacts with the ArchivesSpace database. The API endpoints are defined in detail below.
 
-The HTML template at `frontend/views/top_containers/bulk_operations/_results.html.erb` overrides the default template for search results displayed by the ArchivesSpace Manage Top Containers functionality. The customization modifies the default template by adding a column for the container type and by hiding the columns "ILS Holding ID" and "Exported to ILS." This file should be compared against the default template in the ArchivesSpace repository for each new ArchivesSpace release.
+The HTML template at `frontend/views/top_containers/bulk_operations/_results.html.erb` overrides the default template for search results displayed by the ArchivesSpace Manage Top Containers functionality. The customization modifies the default template by hiding the columns "ILS Holding ID" and "Exported to ILS." This file should be compared against the default template in the ArchivesSpace repository for each new ArchivesSpace release.
 
 ## API Endpoints
 

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -67,7 +67,7 @@
           <% end %>
         </td>
         <td class="top-container-profile"><%= Array(doc['container_profile_display_string_u_sstr']).first %></td>
-        <td><%= container_json['type'] %></td>
+        <td class="top-container-type"><%= container_json['type'] %></td>
         <td class="top-container-indicator"><%= container_json['indicator'] %></td>
         <td class="top-container-barcode"><%= container_json['barcode'] %></td>
         <td class="top-container-current-location"><%= Array(doc['location_display_string_u_sstr']).first %></td>


### PR DESCRIPTION
The default template for `top_containers/bulk_operations/_results.html.erb` was updated for ArchivesSpace v2.5.2 to include the top container type column that was added by our customization. Updating the README to reflect the remaining customizations in our template that are different from the default ArchivesSpace template.